### PR TITLE
Modify config param to model from modelName

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Example `config.yaml`:
 
 ```yaml
 backend: "anthropic"
-modelName: "claude-3-5-sonnet-20241022"
+model: "claude-3-5-sonnet-20241022"
 stream: true
 maxTokens: 2048
 systemPrompt: "You are a helpful assistant."
@@ -67,6 +67,7 @@ systemPrompt: "You are a helpful assistant."
 ## Environment Variables
 
 - `OPENAI_API_KEY`: OpenAI API key
+- `OPENAI_BASE_URL`: Override for OpenAI API Base URL
 - `ANTHROPIC_API_KEY`: Anthropic API key
 - `GOOGLE_API_KEY`: Google AI API key
 

--- a/config.go
+++ b/config.go
@@ -30,7 +30,7 @@ var tokenLimits = map[string]int{
 
 type Config struct {
 	Backend     string  `yaml:"backend"`
-	Model       string  `yaml:"modelName"`
+	Model       string  `yaml:"model"`
 	Stream      bool    `yaml:"stream"`
 	MaxTokens   int     `yaml:"maxTokens"`
 	Temperature float64 `yaml:"temperature"`

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@
 # # The backend to use.
 # backend: "openai"
 # # The model to use.
-# modelName: "gpt-4o"
+# model: "gpt-4o"
 # # Whether or not to stream output.
 # stream: true
 # Optional system prompt.


### PR DESCRIPTION
Also add OPENAI_BASE_URL to README to allow for override of the URL to point to your own OpenAI compatibale API.