### PR TITLE
history: add automatically named history files

### DIFF
--- a/cmd/cgpt/main.go
+++ b/cmd/cgpt/main.go
@@ -38,6 +38,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -106,6 +107,16 @@ func run(ctx context.Context, opts cgpt.RunOptions, flagSet *pflag.FlagSet) erro
 	opts.Config = fileConfig
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// Creates the default save path if it doesn't exist
+	if dir, _ := os.UserHomeDir(); dir != "" {
+		err := os.MkdirAll(filepath.Join(dir, ".cgpt"), 0755)
+		if err != nil {
+			fmt.Fprintf(opts.Stderr, "Failed to create default save path: %v\n", err)
+		} else {
+			fmt.Fprintf(opts.Stderr, "Created default save path: %s\n", filepath.Join(dir, ".cgpt"))
+		}
 	}
 
 	// Initialize the model (the llms.Model interface)

--- a/completion.go
+++ b/completion.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
+	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/tmc/cgpt/interactive"
@@ -288,9 +291,34 @@ func (s *CompletionService) runOneShotCompletion(ctx context.Context, runCfg Run
 func (s *CompletionService) runContinuousCompletionStreaming(ctx context.Context, runCfg RunOptions) error {
 	fmt.Fprintf(s.Stderr, "\033[38;5;240mcgpt: Running in continuous mode. Press ctrl+c to exit.\033[0m\n")
 
+	// Setup context with cancellation
+	ctxWithCancel, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Set up shutdown handler to catch ctrl+c and generate title
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		<-c
+		fmt.Fprintf(s.Stderr, "\n\033[38;5;240mcgpt: Generating descriptive title for chat history...\033[0m\n")
+
+		// Create a new timeout context for title generation
+		titleCtx, titleCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer titleCancel()
+
+		// Generate a title and rename the history file
+		if err := s.renameChatHistory(titleCtx); err != nil {
+			fmt.Fprintf(s.Stderr, "\033[38;5;240mcgpt: Failed to rename history: %v\033[0m\n", err)
+		}
+
+		// Now cancel the main context
+		cancel()
+	}()
+
 	// If we have processed inputs, generate an initial response
 	if len(s.payload.Messages) > 0 && s.payload.Messages[len(s.payload.Messages)-1].Role == llms.ChatMessageTypeHuman {
-		if err := s.generateResponse(ctx, runCfg); err != nil {
+		if err := s.generateResponse(ctxWithCancel, runCfg); err != nil {
 			return fmt.Errorf("failed to generate initial response: %w", err)
 		}
 	}
@@ -301,7 +329,7 @@ func (s *CompletionService) runContinuousCompletionStreaming(ctx context.Context
 			return interactive.ErrEmptyInput
 		}
 		s.payload.addUserMessage(input)
-		return s.generateResponse(ctx, runCfg)
+		return s.generateResponse(ctxWithCancel, runCfg)
 	}
 
 	sessionConfig := interactive.Config{
@@ -316,7 +344,18 @@ func (s *CompletionService) runContinuousCompletionStreaming(ctx context.Context
 		return err
 	}
 
-	return session.Run()
+	err = session.Run()
+
+	// Before returning, try to rename the history file with a descriptive title
+	if ctxWithCancel.Err() == nil { // Only if we haven't already done it in signal handler
+		rctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if renameErr := s.renameChatHistory(rctx); renameErr != nil {
+			fmt.Fprintf(s.Stderr, "\033[38;5;240mcgpt: Failed to rename history: %v\033[0m\n", renameErr)
+		}
+	}
+
+	return err
 }
 
 // Non-streaming version of continuous completion.
@@ -402,4 +441,68 @@ func (s *CompletionService) generateResponse(ctx context.Context, runCfg RunOpti
 // Whitespace is trimmed from the end of the message.
 func (s *CompletionService) SetNextCompletionPrefill(content string) {
 	s.nextCompletionPrefill = strings.TrimRight(content, " \t\n")
+}
+
+// generateHistoryTitle sends the conversation history to the LLM to generate a descriptive title
+func (s *CompletionService) generateHistoryTitle(ctx context.Context) (string, error) {
+	// Don't try to generate a title if we have no messages
+	if len(s.payload.Messages) < 2 {
+		return "empty-chat", nil
+	}
+
+	prompt := "Generate a kebab case title for the following conversation. An example is debug-rust-code or explain-quantum-mechanics."
+	msgLimit := min(len(s.payload.Messages), 10)
+	for _, m := range s.payload.Messages[:msgLimit] {
+		for _, p := range m.Parts {
+			prompt += fmt.Sprint(p)
+		}
+	}
+
+	completion, err := llms.GenerateFromSinglePrompt(ctx, s.model, prompt)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate title: %w", err)
+	}
+
+	fmt.Println("completion", completion)
+
+	// If title is too long, truncate it
+	const maxTitleLength = 50
+	if len(completion) > maxTitleLength {
+		completion = completion[:maxTitleLength]
+	}
+
+	return completion, nil
+}
+
+// renameChatHistory generates a title and renames the history file
+func (s *CompletionService) renameChatHistory(ctx context.Context) error {
+	if s.historyOutFile == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get user home directory: %w", err)
+		}
+
+		// Get the current history file path
+		currentPath := filepath.Join(home, ".cgpt", fmt.Sprintf("default-history-%s.yaml", s.sessionTimestamp))
+
+		// Generate a descriptive title
+		title, err := s.generateHistoryTitle(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to generate title: %w", err)
+		}
+
+		// Create new filename with timestamp + title
+		newPath := filepath.Join(home, ".cgpt", fmt.Sprintf("%s.yaml", title))
+
+		// Rename the file
+		if err := os.Rename(currentPath, newPath); err != nil {
+			return fmt.Errorf("failed to rename history file: %w", err)
+		}
+
+		fmt.Fprintf(s.Stderr, "\033[38;5;240mcgpt: Renamed history to: %s\033[0m\n", filepath.Base(newPath))
+
+		// Update the historyOutFile to use the new path
+		s.historyOutFile = newPath
+	}
+	return nil
 }

--- a/completion.go
+++ b/completion.go
@@ -41,6 +41,9 @@ type CompletionService struct {
 	Stdout io.Writer
 	// Stderr is the writer for standard error. If nil, os.Stderr will be used.
 	Stderr io.Writer
+
+	// sessionTimestamp is used to create a consistent history file name for the entire session
+	sessionTimestamp string
 }
 
 type CompletionServiceOption func(*CompletionService)
@@ -80,6 +83,7 @@ func NewCompletionService(cfg *Config, model llms.Model, opts ...CompletionServi
 		completionTimeout: cfg.CompletionTimeout,
 		Stdout:            os.Stdout,
 		Stderr:            os.Stderr,
+		sessionTimestamp:  time.Now().Format("20060102150405"),
 	}
 	for _, opt := range opts {
 		opt(s)

--- a/history.go
+++ b/history.go
@@ -42,7 +42,9 @@ func (s *CompletionService) saveHistory() error {
 		if err != nil {
 			return fmt.Errorf("failed to get user home directory: %w", err)
 		}
-		defaultSavePath := filepath.Join(home, ".cgpt", "default-history.yaml")
+
+		// Use session timestamp instead of generating a new one each time
+		defaultSavePath := filepath.Join(home, ".cgpt", fmt.Sprintf("default-history-%s.yaml", s.sessionTimestamp))
 		err = createHistoryFile(defaultSavePath, s.cfg.Backend, s.payload, s.payload.Messages)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Overview
This PR enhances the chat history functionality by automatically generating descriptive titles for chat sessions and history files. It also adds support for creating a default save path if it doesn't exist.

## Changes Made
- Add automatic generation of descriptive kebab-case titles for chat history on exit
- Implement session timestamp for consistent history file naming throughout a session
- Create default save path (~/.cgpt) if it doesn't exist
- Add graceful shutdown handling to capture Ctrl+C and generate titles before exit
- Refactor history saving logic to support default history paths
- Improve user feedback with status messages during history operations