### PR TITLE
cgpt: add option to disable history and improve history management

### DIFF
--- a/cmd/cgpt/main.go
+++ b/cmd/cgpt/main.go
@@ -112,11 +112,14 @@ func run(ctx context.Context, opts cgpt.RunOptions, flagSet *pflag.FlagSet) erro
 
 	// Creates the default save path if it doesn't exist
 	if dir, _ := os.UserHomeDir(); dir != "" {
-		err := os.MkdirAll(filepath.Join(dir, ".cgpt"), 0755)
-		if err != nil {
-			fmt.Fprintf(opts.Stderr, "Failed to create default save path: %v\n", err)
-		} else {
-			fmt.Fprintf(opts.Stderr, "Created default save path: %s\n", filepath.Join(dir, ".cgpt"))
+		cgptDir := filepath.Join(dir, ".cgpt")
+		if _, err := os.Stat(cgptDir); os.IsNotExist(err) {
+			err := os.MkdirAll(cgptDir, 0755)
+			if err != nil {
+				fmt.Fprintf(opts.Stderr, "Failed to create default save path: %v\n", err)
+			} else {
+				fmt.Fprintf(opts.Stderr, "Created default save path: %s\n", cgptDir)
+			}
 		}
 	}
 
@@ -147,6 +150,7 @@ func run(ctx context.Context, opts cgpt.RunOptions, flagSet *pflag.FlagSet) erro
 	s, err := cgpt.NewCompletionService(opts.Config, model,
 		cgpt.WithStdout(opts.Stdout),
 		cgpt.WithStderr(opts.Stderr),
+		cgpt.WithDisableHistory(opts.DisableHistory),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create completion service: %w", err)

--- a/cmd/cgpt/main.go
+++ b/cmd/cgpt/main.go
@@ -69,6 +69,7 @@ func defineFlags(fs *pflag.FlagSet, opts *cgpt.RunOptions) {
 	fs.StringVarP(&opts.HistoryOut, "history-out", "O", "", "File to store completion history in")
 	fs.StringVar(&opts.HistoryIn, "history-load", "", "File to read completion history from (deprecated)")
 	fs.StringVar(&opts.HistoryOut, "history-save", "", "File to store completion history in (deprecated)")
+	fs.BoolVar(&opts.DisableHistory, "no-history", false, "Disable saving chat history")
 
 	fs.StringVar(&opts.ReadlineHistoryFile, "readline-history-file", "~/.cgpt_history", "File to store readline history in")
 	fs.IntVarP(&opts.NCompletions, "completions", "n", 0, "Number of completions (when running non-interactively with history)")

--- a/completion.go
+++ b/completion.go
@@ -71,6 +71,13 @@ func WithLogger(l *zap.SugaredLogger) CompletionServiceOption {
 	}
 }
 
+// WithDisableHistory sets whether history saving is disabled
+func WithDisableHistory(disable bool) CompletionServiceOption {
+	return func(s *CompletionService) {
+		s.disableHistory = disable
+	}
+}
+
 // NewCompletionService creates a new CompletionService with the given configuration.
 func NewCompletionService(cfg *Config, model llms.Model, opts ...CompletionServiceOption) (*CompletionService, error) {
 	if cfg == nil {
@@ -477,6 +484,9 @@ func (s *CompletionService) generateHistoryTitle(ctx context.Context) (string, e
 
 // renameChatHistory generates a title and renames the history file
 func (s *CompletionService) renameChatHistory(ctx context.Context) error {
+	if s.disableHistory {
+		return nil
+	}
 	if s.historyOutFile == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {

--- a/completion.go
+++ b/completion.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"slices"
 	"strings"
 	"syscall"
@@ -273,6 +272,10 @@ func (s *CompletionService) runOneShotCompletionStreaming(ctx context.Context, r
 	if err := s.saveHistory(); err != nil {
 		return fmt.Errorf("failed to save history: %w", err)
 	}
+
+	if err := s.renameChatHistory(ctx); err != nil {
+		return fmt.Errorf("failed to rename history: %w", err)
+	}
 	return nil
 }
 
@@ -291,6 +294,9 @@ func (s *CompletionService) runOneShotCompletion(ctx context.Context, runCfg Run
 	runCfg.Stdout.Write([]byte(response))
 	if err := s.saveHistory(); err != nil {
 		return fmt.Errorf("failed to save history: %w", err)
+	}
+	if err := s.renameChatHistory(ctx); err != nil {
+		return fmt.Errorf("failed to rename history: %w", err)
 	}
 	return nil
 }
@@ -449,71 +455,4 @@ func (s *CompletionService) generateResponse(ctx context.Context, runCfg RunOpti
 // Whitespace is trimmed from the end of the message.
 func (s *CompletionService) SetNextCompletionPrefill(content string) {
 	s.nextCompletionPrefill = strings.TrimRight(content, " \t\n")
-}
-
-// generateHistoryTitle sends the conversation history to the LLM to generate a descriptive title
-func (s *CompletionService) generateHistoryTitle(ctx context.Context) (string, error) {
-	// Don't try to generate a title if we have no messages
-	if len(s.payload.Messages) < 2 {
-		return "empty-chat", nil
-	}
-
-	prompt := "Generate a kebab case title for the following conversation. An example is debug-rust-code or explain-quantum-mechanics."
-	msgLimit := min(len(s.payload.Messages), 10)
-	for _, m := range s.payload.Messages[:msgLimit] {
-		for _, p := range m.Parts {
-			prompt += fmt.Sprint(p)
-		}
-	}
-
-	completion, err := llms.GenerateFromSinglePrompt(ctx, s.model, prompt)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate title: %w", err)
-	}
-
-	fmt.Println("completion", completion)
-
-	// If title is too long, truncate it
-	const maxTitleLength = 50
-	if len(completion) > maxTitleLength {
-		completion = completion[:maxTitleLength]
-	}
-
-	return completion, nil
-}
-
-// renameChatHistory generates a title and renames the history file
-func (s *CompletionService) renameChatHistory(ctx context.Context) error {
-	if s.disableHistory {
-		return nil
-	}
-	if s.historyOutFile == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("failed to get user home directory: %w", err)
-		}
-
-		// Get the current history file path
-		currentPath := filepath.Join(home, ".cgpt", fmt.Sprintf("default-history-%s.yaml", s.sessionTimestamp))
-
-		// Generate a descriptive title
-		title, err := s.generateHistoryTitle(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to generate title: %w", err)
-		}
-
-		// Create new filename with timestamp + title
-		newPath := filepath.Join(home, ".cgpt", fmt.Sprintf("%s.yaml", title))
-
-		// Rename the file
-		if err := os.Rename(currentPath, newPath); err != nil {
-			return fmt.Errorf("failed to rename history file: %w", err)
-		}
-
-		fmt.Fprintf(s.Stderr, "\033[38;5;240mcgpt: Renamed history to: %s\033[0m\n", filepath.Base(newPath))
-
-		// Update the historyOutFile to use the new path
-		s.historyOutFile = newPath
-	}
-	return nil
 }

--- a/completion.go
+++ b/completion.go
@@ -34,6 +34,7 @@ type CompletionService struct {
 	historyIn           io.Reader
 	historyOutFile      string
 	readlineHistoryFile string
+	disableHistory      bool
 
 	performCompletionConfig PerformCompletionConfig
 

--- a/history.go
+++ b/history.go
@@ -37,6 +37,9 @@ func (s *CompletionService) loadHistory() error {
 }
 
 func (s *CompletionService) saveHistory() error {
+	if s.disableHistory {
+		return nil
+	}
 	if s.historyOutFile == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {

--- a/history.go
+++ b/history.go
@@ -1,6 +1,7 @@
 package cgpt
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -83,6 +84,73 @@ func createHistoryFile(historyOutFile string, backend string, payload *ChatCompl
 	}
 	if _, err := f.Write(ybytes); err != nil {
 		return fmt.Errorf("failed to write history file %q: %w", historyOutFile, err)
+	}
+	return nil
+}
+
+// generateHistoryTitle sends the conversation history to the LLM to generate a descriptive title
+func (s *CompletionService) generateHistoryTitle(ctx context.Context) (string, error) {
+	// Don't try to generate a title if we have no messages
+	if len(s.payload.Messages) < 2 {
+		return "empty-chat", nil
+	}
+
+	prompt := "Generate a kebab case title for the following conversation. An example is debug-rust-code or explain-quantum-mechanics."
+	msgLimit := min(len(s.payload.Messages), 10)
+	for _, m := range s.payload.Messages[:msgLimit] {
+		for _, p := range m.Parts {
+			prompt += fmt.Sprint(p)
+		}
+	}
+
+	completion, err := llms.GenerateFromSinglePrompt(ctx, s.model, prompt)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate title: %w", err)
+	}
+
+	fmt.Println("completion", completion)
+
+	// If title is too long, truncate it
+	const maxTitleLength = 50
+	if len(completion) > maxTitleLength {
+		completion = completion[:maxTitleLength]
+	}
+
+	return completion, nil
+}
+
+// renameChatHistory generates a title and renames the history file
+func (s *CompletionService) renameChatHistory(ctx context.Context) error {
+	if s.disableHistory {
+		return nil
+	}
+	if s.historyOutFile == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get user home directory: %w", err)
+		}
+
+		// Get the current history file path
+		currentPath := filepath.Join(home, ".cgpt", fmt.Sprintf("default-history-%s.yaml", s.sessionTimestamp))
+
+		// Generate a descriptive title
+		title, err := s.generateHistoryTitle(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to generate title: %w", err)
+		}
+
+		// Create new filename with timestamp + title
+		newPath := filepath.Join(home, ".cgpt", fmt.Sprintf("%s.yaml", title))
+
+		// Rename the file
+		if err := os.Rename(currentPath, newPath); err != nil {
+			return fmt.Errorf("failed to rename history file: %w", err)
+		}
+
+		fmt.Fprintf(s.Stderr, "\033[38;5;240mcgpt: Renamed history to: %s\033[0m\n", filepath.Base(newPath))
+
+		// Update the historyOutFile to use the new path
+		s.historyOutFile = newPath
 	}
 	return nil
 }

--- a/options.go
+++ b/options.go
@@ -33,6 +33,7 @@ type RunOptions struct {
 	HistoryOut          string `json:"historyOut,omitempty" yaml:"historyOut,omitempty"`
 	ReadlineHistoryFile string `json:"readlineHistoryFile,omitempty" yaml:"readlineHistoryFile,omitempty"`
 	NCompletions        int    `json:"nCompletions,omitempty" yaml:"nCompletions,omitempty"`
+	DisableHistory      bool   `json:"disableHistory,omitempty" yaml:"disableHistory,omitempty"`
 
 	// I/O
 	Stdout io.Writer `json:"-" yaml:"-"`


### PR DESCRIPTION
## Overview
This PR enhances the chat history functionality by adding an option to disable history saving and improving the management of history files. It also refactors the code by moving history-related functions to a more appropriate location.

## Changes Made
- Added a new `--no-history` flag to disable saving chat history
- Fixed directory existence check before creating the default save path
- Moved history title generation functions from `completion.go` to `history.go`
- Added proper history disabling checks in save and rename functions
- Added support for the new history option in the CompletionService
- Improved error handling for history-related operations