### PR TITLE
Compatibility with any openai-compliant api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ cgpt is a command-line tool for interacting with Large Language Models (LLMs) us
 
 ## Features
 
-- Supports multiple backends: Anthropic, OpenAI, Ollama, and Google AI
+- Supports multiple backends: Anthropic, OpenAI (and OpenAI compatible endpoints with a provided base url), Ollama, and Google AI
 - Interactive mode for continuous conversations
 - Streaming output
 - History management

--- a/README.md
+++ b/README.md
@@ -175,3 +175,29 @@ This project is licensed under the ISC License. See the [LICENSE](LICENSE) file 
 This README provides an overview of the cgpt tool, including its features, installation instructions, usage examples, configuration options, and information about the Vim plugin. It also includes details about the supported backends and environment variables for API keys.
 
 Happy hacking! 🚀
+
+
+## Local Development
+1. Clone and CD into the repository:
+```bash
+git clone https://github.com/tmc/cgpt
+cd cgpt
+```
+
+2. Ensure GO is installed locally [Or, install:](https://go.dev/doc/install)
+```bash
+go version
+```
+
+3. Setup environment variables, type this into terminal
+```bash
+export ANTHROPIC_API_KEY='your-anthropic-api-key'
+export OPENAI_API_KEY='your-openai-api-key'
+export GOOGLE_API_KEY='your-google-ai-api-key'
+```
+
+4. Build project locally and run
+```bash
+go build -o cgpt ./cmd/cgpt
+./cgpt [flags] [prompt]
+```

--- a/config.go
+++ b/config.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var defaultBackend = "dummy" // Configurable via 'CGPT_BACKEND" (or via configuration files).
+var defaultBackend = "anthropic" // Configurable via 'CGPT_BACKEND" (or via configuration files).
 
 var defaultModels = map[string]string{
 	"anthropic": "claude-3-7-sonnet-20250219",
@@ -49,7 +49,7 @@ type Config struct {
 	OpenAIAPIKey    string `yaml:"openaiAPIKey"`
 	AnthropicAPIKey string `yaml:"anthropicAPIKey"`
 	GoogleAPIKey    string `yaml:"googleAPIKey"`
-	OpenAIBaseURL 	string `yaml:"openai_base_url"`
+	OpenAIBaseURL 	string `yaml:"openaiBaseURL"`
 
 }
 
@@ -160,7 +160,7 @@ func setupViper(v *viper.Viper, flagSet *pflag.FlagSet) {
 	v.BindEnv("openaiAPIKey", "OPENAI_API_KEY")
 	v.BindEnv("anthropicAPIKey", "ANTHROPIC_API_KEY")
 	v.BindEnv("googleAPIKey", "GOOGLE_API_KEY")
-	v.BindEnv("openai_base_url", "OPENAI_BASE_URL")
+	v.BindEnv("openaiBaseURL", "OPENAI_BASE_URL")
 
 
 	// Set config file if specified in flags

--- a/config.go
+++ b/config.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var defaultBackend = "anthropic" // Configurable via 'CGPT_BACKEND" (or via configuration files).
+var defaultBackend = "dummy" // Configurable via 'CGPT_BACKEND" (or via configuration files).
 
 var defaultModels = map[string]string{
 	"anthropic": "claude-3-7-sonnet-20250219",
@@ -49,6 +49,8 @@ type Config struct {
 	OpenAIAPIKey    string `yaml:"openaiAPIKey"`
 	AnthropicAPIKey string `yaml:"anthropicAPIKey"`
 	GoogleAPIKey    string `yaml:"googleAPIKey"`
+	OpenAIBaseURL 	string `yaml:"openai_base_url"`
+
 }
 
 // LoadConfig loads the configuration from various sources in the following order of precedence:
@@ -158,6 +160,8 @@ func setupViper(v *viper.Viper, flagSet *pflag.FlagSet) {
 	v.BindEnv("openaiAPIKey", "OPENAI_API_KEY")
 	v.BindEnv("anthropicAPIKey", "ANTHROPIC_API_KEY")
 	v.BindEnv("googleAPIKey", "GOOGLE_API_KEY")
+	v.BindEnv("openai_base_url", "OPENAI_BASE_URL")
+
 
 	// Set config file if specified in flags
 	if flagConfigFilePath := flagSet.Lookup("config"); flagConfigFilePath.Changed {

--- a/config.go
+++ b/config.go
@@ -51,6 +51,11 @@ type Config struct {
 	GoogleAPIKey    string `yaml:"googleAPIKey"`
 	OpenAIBaseURL 	string `yaml:"openaiBaseURL"`
 
+
+	// Reference on the similarly named variables:
+	// OpenAIBaseURL is used in struct pulled in models.go
+	// openaiBaseURL is used in YAML file (config.yaml) by end user
+	// OPENAI_BASE_URL is used if they set through bash `export OPENAI_BASE_URL="xyz"`
 }
 
 // LoadConfig loads the configuration from various sources in the following order of precedence:

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,0 @@
-# backend: "openai"
-# model: "Meta-Llama-4-Maverick-17B-128E-Instruct-FP8"
-# openaiBaseURL: "https://chatapi.akash.network/api/v1/"
-# openaiAPIKey: "sk-it1KlU6reat-WDeEecz5lg"

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+# backend: "openai"
+# model: "Meta-Llama-4-Maverick-17B-128E-Instruct-FP8"
+# openaiBaseURL: "https://chatapi.akash.network/api/v1/"
+# openaiAPIKey: "sk-it1KlU6reat-WDeEecz5lg"

--- a/models.go
+++ b/models.go
@@ -59,16 +59,10 @@ var modelConstructors = map[string]modelConstructor{
 		if cfg.OpenAIAPIKey != "" {
 			options = append(options, openai.WithToken(cfg.OpenAIAPIKey))
 		}
-
-	
 		if cfg.OpenAIBaseURL != "" {
-			fmt.Printf("cgpt: using OpenAI base URL: %s\n", cfg.OpenAIBaseURL)
+			// fmt.Printf("cgpt: using OpenAI base URL: %s\n", cfg.OpenAIBaseURL)
 			options = append(options, openai.WithBaseURL(cfg.OpenAIBaseURL))
-		} else {
-			fmt.Printf("cgpt: using ")
-
 		}
-
 		if mo.httpClient != nil {
 			options = append(options, openai.WithHTTPClient(mo.httpClient))
 		}

--- a/models.go
+++ b/models.go
@@ -59,6 +59,16 @@ var modelConstructors = map[string]modelConstructor{
 		if cfg.OpenAIAPIKey != "" {
 			options = append(options, openai.WithToken(cfg.OpenAIAPIKey))
 		}
+
+	
+		if cfg.OpenAIBaseURL != "" {
+			fmt.Printf("cgpt: using OpenAI base URL: %s\n", cfg.OpenAIBaseURL)
+			options = append(options, openai.WithBaseURL(cfg.OpenAIBaseURL))
+		} else {
+			fmt.Printf("cgpt: using ")
+
+		}
+
 		if mo.httpClient != nil {
 			options = append(options, openai.WithHTTPClient(mo.httpClient))
 		}


### PR DESCRIPTION
Many openai compatible endpoints provide free inference (openrouter, akashchat api, targon, etc), which has become my go-to for free inference.

This pull request includes changes that allows the user to set a base openai endpoint url, so any compatible api endpoint will work instead of just the default openai.com endpoint.

To use, either:

1. Through bash:
```
export OPENAI_BASE_URL="https://chatapi.akash.network/api/v1/"
```

Or

2. Through config.yaml:
```
model: "Meta-Llama-4-Maverick-17B-128E-Instruct-FP8"
openaiBaseURL: "https://chatapi.akash.network/api/v1/"
```

Thanks!