### PR TITLE
cgpt: add multi-provider reasoning support

### DIFF
--- a/cmd/cgpt/main.go
+++ b/cmd/cgpt/main.go
@@ -91,6 +91,14 @@ func defineFlags(fs *pflag.FlagSet, opts *cgpt.RunOptions) {
 	fs.IntVarP(&opts.Config.MaxTokens, "max-tokens", "t", 0, "Maximum tokens to generate")
 	fs.Float64VarP(&opts.Config.Temperature, "temperature", "T", 0.05, "Temperature for sampling")
 
+	// Prompt caching and reasoning features
+	fs.BoolVar(&opts.Config.PromptCaching, "prompt-caching", false, "Enable prompt caching (reduces costs for repeated prompts)")
+	fs.StringVar(&opts.Config.ThinkingMode, "thinking-mode", "none", "Thinking mode for reasoning models (none, low, medium, high, auto)")
+	fs.IntVar(&opts.Config.ThinkingBudget, "thinking-budget", 0, "Explicit token budget for thinking/reasoning (overrides thinking-mode)")
+	fs.BoolVar(&opts.Config.ShowCosts, "show-costs", false, "Show token usage and cost estimates after completion")
+	fs.BoolVar(&opts.Config.ShowReasoning, "show-reasoning", false, "Show reasoning/thinking content when available")
+	fs.BoolVar(&opts.Config.InterleavedThinking, "interleaved-thinking", false, "Enable interleaved thinking mode (Claude 4+ only)")
+
 	// Config file path
 	fs.StringVar(&opts.ConfigPath, "config", "config.yaml", "Path to the configuration file")
 }
@@ -120,6 +128,13 @@ func run(ctx context.Context, opts cgpt.RunOptions, flagSet *pflag.FlagSet) erro
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
+	// Validate thinking mode configuration and show warnings
+	if warnings := opts.Config.ValidateThinkingConfig(); len(warnings) > 0 {
+		for _, warning := range warnings {
+			fmt.Fprintln(opts.Stderr, warning)
+		}
+	}
+
 	// Creates the default save path if it doesn't exist
 	if dir, _ := os.UserHomeDir(); dir != "" {
 		cgptDir := filepath.Join(dir, ".cgpt")
@@ -138,7 +153,8 @@ func run(ctx context.Context, opts cgpt.RunOptions, flagSet *pflag.FlagSet) erro
 	// if debug mode is on, attach the debug http client:
 	if opts.DebugMode {
 		fmt.Fprintln(opts.Stderr, "Debug mode enabled")
-		modelOpts = append(modelOpts, cgpt.WithHTTPClient(httputil.DebugHTTPClient))
+		// Use SSEDebugClient for pretty-printed JSON requests and raw SSE streaming output
+		modelOpts = append(modelOpts, cgpt.WithHTTPClient(httputil.SSEDebugClient))
 	}
 	model, err := cgpt.InitializeModel(opts.Config, modelOpts...)
 	if err != nil {

--- a/cmd/cgpt/main_test.go
+++ b/cmd/cgpt/main_test.go
@@ -406,6 +406,9 @@ func TestDuplicateAIRole(t *testing.T) {
 }
 
 func TestMain(t *testing.T) {
+	// Set dummy backend to avoid trying to connect to ollama
+	t.Setenv("CGPT_BACKEND", "dummy")
+	
 	tests := []struct {
 		name    string
 		args    []string

--- a/cmd/cgpt/main_test.go
+++ b/cmd/cgpt/main_test.go
@@ -112,6 +112,42 @@ func Test(t *testing.T) {
 			model:   "dummy-model",
 			args:    []string{"-I", "input.yaml", "-O", "output.yaml"},
 		},
+		{
+			name:    "prompt caching",
+			backend: "dummy",
+			model:   "dummy-model",
+			args:    []string{"--prompt-caching"},
+		},
+		{
+			name:    "thinking mode",
+			backend: "dummy",
+			model:   "dummy-model",
+			args:    []string{"--thinking-mode", "medium"},
+		},
+		{
+			name:    "thinking budget",
+			backend: "dummy",
+			model:   "dummy-model",
+			args:    []string{"--thinking-budget", "2000"},
+		},
+		{
+			name:    "show costs",
+			backend: "dummy",
+			model:   "dummy-model",
+			args:    []string{"--show-costs"},
+		},
+		{
+			name:    "combined features",
+			backend: "dummy",
+			model:   "dummy-model",
+			args:    []string{"--prompt-caching", "--thinking-mode", "high", "--show-costs"},
+		},
+		{
+			name:    "prompt caching env",
+			backend: "dummy",
+			model:   "dummy-model",
+			args:    []string{},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/cgpt/main_test.go
+++ b/cmd/cgpt/main_test.go
@@ -152,10 +152,10 @@ func Test(t *testing.T) {
 				// Check if ollama is available by attempting to initialize
 				testCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 				defer cancel()
-				
+
 				// Try to run the test with a short timeout
 				runTest(t, testCtx, opts, fs, newTestLogger(t))
-				
+
 				// If context timed out or we got an error, skip the test
 				if testCtx.Err() != nil || strings.Contains(errBuf.String(), "failed to connect") || strings.Contains(errBuf.String(), "connection refused") {
 					t.Skip("Skipping ollama test - ollama not available")
@@ -163,7 +163,7 @@ func Test(t *testing.T) {
 			} else {
 				runTest(t, context.Background(), opts, fs, newTestLogger(t))
 			}
-			
+
 			if *update {
 				updateGoldenFile(t, testInputFile, txtarComment, files, outBuf.Bytes(), errBuf.Bytes(), files["http_payload"])
 				t.SkipNow()
@@ -408,7 +408,7 @@ func TestDuplicateAIRole(t *testing.T) {
 func TestMain(t *testing.T) {
 	// Set dummy backend to avoid trying to connect to ollama
 	t.Setenv("CGPT_BACKEND", "dummy")
-	
+
 	tests := []struct {
 		name    string
 		args    []string

--- a/completion.go
+++ b/completion.go
@@ -33,13 +33,13 @@ type CompletionService struct {
 
 	historyIn           io.Reader
 	historyOutFile      string
-	historyFile         *os.File      // File handle for new history system
+	historyFile         *os.File // File handle for new history system
 	historyManager      *historyManager
 	historyMetadata     *historyMetadata // Metadata for the history file
 	readlineHistoryFile string
 	disableHistory      bool
 	autoNameHistory     bool
-	autoHistory         bool  // Whether this is an auto-generated session
+	autoHistory         bool // Whether this is an auto-generated session
 
 	performCompletionConfig PerformCompletionConfig
 
@@ -92,7 +92,6 @@ func WithUseLegacyMaxTokens(useLegacy bool) CompletionServiceOption {
 		s.useLegacyMaxTokens = useLegacy
 	}
 }
-
 
 // NewCompletionService creates a new CompletionService with the given configuration.
 func NewCompletionService(cfg *Config, model llms.Model, opts ...CompletionServiceOption) (*CompletionService, error) {
@@ -159,10 +158,10 @@ func (s *CompletionService) Run(ctx context.Context, runCfg RunOptions) error {
 		return fmt.Errorf("input handling error: %w", err)
 	}
 	err := s.executeCompletion(ctx, runCfg)
-	
+
 	// Handle post-completion tasks (naming, cleanup)
 	s.finalizeHistory(ctx, runCfg)
-	
+
 	return err
 }
 
@@ -181,7 +180,7 @@ func (s *CompletionService) configure(runCfg RunOptions) error {
 	if err := s.setupHistory(runCfg); err != nil {
 		fmt.Fprintln(s.Stderr, err)
 	}
-	
+
 	if runCfg.Prefill != "" {
 		s.SetNextCompletionPrefill(runCfg.Prefill)
 	}
@@ -258,7 +257,6 @@ func (s *CompletionService) loadedWithHistory() bool {
 	return s.historyIn != nil
 }
 
-
 // setupHistory handles all history flag combinations
 func (s *CompletionService) setupHistory(runCfg RunOptions) error {
 	// Validate flag combinations
@@ -272,24 +270,24 @@ func (s *CompletionService) setupHistory(runCfg RunOptions) error {
 	if runCfg.Continue {
 		flagCount++
 	}
-	
+
 	if flagCount > 1 {
 		return fmt.Errorf("cannot combine -H/--history with -I/-O or -C flags")
 	}
-	
+
 	// Handle each flag type
 	if runCfg.Continue {
 		return s.setupContinue()
 	}
-	
+
 	if runCfg.History != "" {
 		return s.setupHistoryFile(runCfg.History)
 	}
-	
+
 	if runCfg.HistoryIn != "" || runCfg.HistoryOut != "" {
 		return s.setupExplicitHistory(runCfg.HistoryIn, runCfg.HistoryOut)
 	}
-	
+
 	// No history flags = no history
 	s.disableHistory = true
 	return nil
@@ -301,17 +299,17 @@ func (s *CompletionService) setupContinue() error {
 	if err := os.MkdirAll(sessionsDir, 0755); err != nil {
 		return fmt.Errorf("failed to create sessions directory: %w", err)
 	}
-	
+
 	pattern := filepath.Join(sessionsDir, "*.yaml")
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
 		return fmt.Errorf("failed to find sessions: %w", err)
 	}
-	
+
 	if len(matches) == 0 {
 		return fmt.Errorf("no previous sessions found")
 	}
-	
+
 	// Find most recent
 	var latest string
 	var latestTime time.Time
@@ -325,7 +323,7 @@ func (s *CompletionService) setupContinue() error {
 			latestTime = info.ModTime()
 		}
 	}
-	
+
 	return s.setupHistoryFile(latest)
 }
 
@@ -339,15 +337,15 @@ func (s *CompletionService) setupHistoryFile(historySpec string) error {
 		}
 		s.historyOutFile = path
 		s.historyFile = file
-		s.autoHistory = true  // Mark this as an auto-generated session
-		
+		s.autoHistory = true // Mark this as an auto-generated session
+
 		// Initialize metadata for new session
 		s.historyMetadata = &historyMetadata{
 			Created: time.Now().Format(time.RFC3339),
 		}
 		return nil
 	}
-	
+
 	// Explicit file - read from it if exists, write to it
 	if _, err := os.Stat(historySpec); err == nil {
 		// File exists, load it
@@ -357,18 +355,18 @@ func (s *CompletionService) setupHistoryFile(historySpec string) error {
 		}
 		s.historyIn = f
 		defer f.Close()
-		
+
 		if err := s.loadHistory(); err != nil {
 			return fmt.Errorf("failed to load history: %w", err)
 		}
 	}
-	
+
 	// Setup for writing
 	f, err := os.OpenFile(historySpec, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open history file for writing: %w", err)
 	}
-	
+
 	s.historyOutFile = historySpec
 	s.historyFile = f
 	return nil
@@ -384,11 +382,11 @@ func (s *CompletionService) setupExplicitHistory(historyIn, historyOut string) e
 		}
 		s.historyIn = f
 		defer f.Close()
-		
+
 		if err := s.loadHistory(); err != nil {
 			return fmt.Errorf("failed to load history: %w", err)
 		}
-		
+
 		// Track fork if outputting to a different file
 		if historyOut != "" && historyOut != historyIn && historyOut != "-" {
 			if s.historyMetadata == nil {
@@ -401,7 +399,7 @@ func (s *CompletionService) setupExplicitHistory(historyIn, historyOut string) e
 			}
 		}
 	}
-	
+
 	// Setup output if specified
 	if historyOut != "" {
 		if historyOut == "-" {
@@ -419,10 +417,9 @@ func (s *CompletionService) setupExplicitHistory(historyIn, historyOut string) e
 		// If only input specified, disable saving
 		s.disableHistory = true
 	}
-	
+
 	return nil
 }
-
 
 func (s *CompletionService) getLastUserMessage() string {
 	if len(s.payload.Messages) == 0 {
@@ -662,7 +659,7 @@ func (s *CompletionService) finalizeHistory(ctx context.Context, runCfg RunOptio
 	// Close history file if open
 	if s.historyFile != nil && s.historyFile != os.Stdout {
 		s.historyFile.Close()
-		
+
 		// Note: Named session functionality removed for simplicity
 	}
 }

--- a/completion.go
+++ b/completion.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/tmc/cgpt/interactive"
 	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/anthropic"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -206,7 +207,22 @@ func (s *CompletionService) setupSystemPrompt() error {
 	}
 
 	s.payload.Messages = append([]llms.MessageContent(nil), s.payload.Messages...)
-	sysMsg := llms.TextParts(llms.ChatMessageTypeSystem, s.cfg.SystemPrompt)
+
+	// Use addSystemMessage to properly handle cache control when prompt caching is enabled
+	var sysMsg llms.MessageContent
+	if s.cfg.PromptCaching {
+		// When prompt caching is enabled, add cache control to system messages
+		cachedPart := llms.WithCacheControl(
+			llms.TextPart(s.cfg.SystemPrompt),
+			anthropic.EphemeralCache(),
+		)
+		sysMsg = llms.MessageContent{
+			Role:  llms.ChatMessageTypeSystem,
+			Parts: []llms.ContentPart{cachedPart},
+		}
+	} else {
+		sysMsg = llms.TextParts(llms.ChatMessageTypeSystem, s.cfg.SystemPrompt)
+	}
 
 	sysIdx := slices.IndexFunc(s.payload.Messages, func(m llms.MessageContent) bool {
 		return m.Role == "system"
@@ -437,6 +453,26 @@ func (s *CompletionService) getLastUserMessage() string {
 func (s *CompletionService) runOneShotCompletionStreaming(ctx context.Context, runCfg RunOptions) error {
 	s.logger.Debug("running one-shot completion with streaming")
 
+	// In debug mode, the SSEDebugClient shows the request JSON and raw SSE frames.
+	// We still call the normal streaming but consume the processed output silently
+	// since the raw HTTP response is handled by the debug client.
+	if runCfg.DebugMode {
+		s.payload.Stream = true
+		streamPayloads, err := s.PerformCompletionStreaming(ctx, s.payload, PerformCompletionConfig{
+			ShowSpinner: false, // No spinner in debug mode
+			EchoPrefill: runCfg.EchoPrefill,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to perform completion streaming: %w", err)
+		}
+		// In debug mode, consume the processed chunks but don't output them
+		// The raw HTTP response (including SSE frames) is handled by SSEDebugClient
+		for range streamPayloads {
+			// Consume processed chunks silently - raw SSE already shown
+		}
+		return nil
+	}
+
 	s.payload.Stream = true
 	streamPayloads, err := s.PerformCompletionStreaming(ctx, s.payload, PerformCompletionConfig{
 		ShowSpinner: runCfg.ShowSpinner,
@@ -466,6 +502,18 @@ func (s *CompletionService) runOneShotCompletionStreaming(ctx context.Context, r
 // Non-streaming version of one-shot completion.
 func (s *CompletionService) runOneShotCompletion(ctx context.Context, runCfg RunOptions) error {
 	s.logger.Debug("running one-shot completion")
+
+	// In debug mode, the SSEDebugClient shows the request JSON and response.
+	// Skip normal processing to avoid duplicate output
+	if runCfg.DebugMode {
+		s.payload.Stream = false
+		_, err := s.PerformCompletion(ctx, s.payload, PerformCompletionConfig{
+			ShowSpinner: false, // No spinner in debug mode
+			EchoPrefill: runCfg.EchoPrefill,
+		})
+		// Don't process the response - raw output already shown by SSEDebugClient
+		return err
+	}
 
 	s.payload.Stream = false
 	response, err := s.PerformCompletion(ctx, s.payload, PerformCompletionConfig{

--- a/config.go
+++ b/config.go
@@ -169,6 +169,106 @@ type Config struct {
 	OpenRouterAPIKey string `yaml:"openrouterAPIKey"`
 	AnthropicAPIKey  string `yaml:"anthropicAPIKey"`
 	GoogleAPIKey     string `yaml:"googleAPIKey"`
+
+	// Prompt caching (works with multiple backends)
+	PromptCaching bool `yaml:"promptCaching"`
+
+	// Thinking/reasoning mode for models that support it
+	ThinkingMode        string `yaml:"thinkingMode"`
+	ThinkingBudget      int    `yaml:"thinkingBudget"`
+	ShowCosts           bool   `yaml:"showCosts"`
+	ShowReasoning       bool   `yaml:"showReasoning"`
+	InterleavedThinking bool   `yaml:"interleavedThinking"`
+}
+
+// ValidateThinkingConfig validates thinking mode configuration and returns warnings
+func (c *Config) ValidateThinkingConfig() []string {
+	var warnings []string
+
+	// Check if thinking features are used with incompatible backends
+	hasThinking := c.ThinkingBudget > 0 || (c.ThinkingMode != "" && c.ThinkingMode != "none") || c.InterleavedThinking
+
+	// Define which backends support reasoning/thinking
+	reasoningBackends := map[string]string{
+		"anthropic":  "Extended Thinking",
+		"openai":     "Reasoning Tokens (o1+ models)",
+		"googleai":   "Thinking Budget (Gemini 2.5+ models)",
+		"openrouter": "Reasoning Tokens (provider-dependent)",
+		"ollama":     "Thinking Mode (DeepSeek-R1, QwQ, etc.)",
+	}
+
+	if hasThinking {
+		if _, supported := reasoningBackends[c.Backend]; supported {
+			// Supported backend - add specific notes
+			if c.Backend == "openai" {
+				warnings = append(warnings, fmt.Sprintf("Note: Using OpenAI Reasoning Tokens. Requires o1+ models (o1, o1-mini, o3, etc.)"))
+			} else if c.Backend == "googleai" {
+				warnings = append(warnings, fmt.Sprintf("Note: Using Google Gemini Thinking Budget. Requires Gemini 2.5+ models"))
+			} else if c.Backend == "ollama" {
+				warnings = append(warnings, fmt.Sprintf("Note: Using Ollama Thinking Mode. Requires reasoning models (deepseek-r1, qwq, etc.)"))
+			}
+		} else {
+			warnings = append(warnings, fmt.Sprintf("Warning: Thinking features not supported by '%s' backend. Supported: %v", c.Backend, getBackendList(reasoningBackends)))
+		}
+	}
+
+	// Validate thinking mode strings
+	if c.ThinkingMode != "" && c.ThinkingMode != "none" {
+		validModes := map[string]bool{
+			"low":    true,
+			"medium": true,
+			"high":   true,
+			"auto":   true,
+		}
+		if !validModes[c.ThinkingMode] {
+			warnings = append(warnings, fmt.Sprintf("Warning: Invalid thinking mode '%s'. Valid options: none, low, medium, high, auto", c.ThinkingMode))
+		}
+	}
+
+	// Backend-specific validation for supported backends
+	if hasThinking {
+		if _, supported := reasoningBackends[c.Backend]; supported {
+			// Temperature validation (Anthropic-specific requirement)
+			if c.Backend == "anthropic" && c.Temperature != 1.0 && c.Temperature != 0.05 {
+				warnings = append(warnings, fmt.Sprintf("Warning: Temperature will be overridden to 1.0 (from %.2f) when thinking is enabled (Anthropic requirement)", c.Temperature))
+			}
+
+			// Budget validation (Anthropic has 1024 minimum, others may vary)
+			if c.ThinkingBudget > 0 {
+				if c.Backend == "anthropic" && c.ThinkingBudget < 1024 {
+					warnings = append(warnings, fmt.Sprintf("Warning: Thinking budget %d is below Anthropic minimum of 1024 tokens, will be adjusted to 1024", c.ThinkingBudget))
+				} else if c.Backend == "googleai" && c.ThinkingBudget < 0 && c.ThinkingBudget != -1 {
+					warnings = append(warnings, fmt.Sprintf("Warning: Google Gemini thinking budget should be positive or -1 for auto-adjust"))
+				}
+			}
+		}
+	}
+
+	// Check max_tokens vs thinking budget relationship (mainly for Anthropic)
+	if c.Backend == "anthropic" && hasThinking && c.MaxTokens > 0 {
+		effectiveBudget := c.ThinkingBudget
+		if effectiveBudget == 0 && c.ThinkingMode != "" && c.ThinkingMode != "none" {
+			effectiveBudget = 1024 // minimum default
+		}
+		// Normalize to API minimum
+		if effectiveBudget > 0 && effectiveBudget < 1024 {
+			effectiveBudget = 1024
+		}
+		if c.MaxTokens <= effectiveBudget {
+			warnings = append(warnings, fmt.Sprintf("Note: max_tokens (%d) will be auto-adjusted to be greater than thinking budget (%d)", c.MaxTokens, effectiveBudget))
+		}
+	}
+
+	return warnings
+}
+
+// getBackendList returns a formatted list of backend names
+func getBackendList(backends map[string]string) []string {
+	var names []string
+	for name := range backends {
+		names = append(names, name)
+	}
+	return names
 }
 
 // LoadConfig loads the configuration from various sources in the following order of precedence:
@@ -306,6 +406,7 @@ func setupViper(v *viper.Viper, flagSet *pflag.FlagSet) {
 	v.BindEnv("openrouterAPIKey", "OPENROUTER_API_KEY")
 	v.BindEnv("anthropicAPIKey", "ANTHROPIC_API_KEY")
 	v.BindEnv("googleAPIKey", "GOOGLE_API_KEY")
+	v.BindEnv("promptCaching", "PROMPT_CACHING", "ANTHROPIC_ENABLE_PROMPT_CACHING")
 
 	// Set config file if specified in flags
 	if flagConfigFilePath := flagSet.Lookup("config"); flagConfigFilePath != nil && flagConfigFilePath.Changed {

--- a/dummy_backend.go
+++ b/dummy_backend.go
@@ -43,17 +43,110 @@ func (d *DummyBackend) Call(ctx context.Context, prompt string, options ...llms.
 func (d *DummyBackend) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
 	dummyText := d.GenerateText()
 	words := strings.Fields(dummyText)
-	response := &llms.ContentResponse{
-		Choices: []*llms.ContentChoice{
-			{
-				Content: strings.Join(words, " "),
-			},
-		},
-	}
 
 	opts := llms.CallOptions{}
 	for _, opt := range options {
 		opt(&opts)
+	}
+
+	// Respect MaxTokens if set (approximate words as tokens)
+	if opts.MaxTokens > 0 && opts.MaxTokens < len(words) {
+		words = words[:opts.MaxTokens]
+	}
+
+	// Calculate mock token counts
+	inputTokenCount := len(messages) * 50 // Assume ~50 tokens per message
+	outputTokenCount := len(words)
+	cachedInputTokens := 0
+	thinkingTokenCount := 0
+	thinkingInputTokens := 0
+	thinkingOutputTokens := 0
+	thinkingCachedTokens := 0
+	thinkingBudgetUsed := 0
+	thinkingBudgetAllocated := 0
+
+	// Check if prompt caching is enabled in metadata
+	promptCachingEnabled := false
+	if opts.Metadata != nil {
+		if enabled, ok := opts.Metadata["prompt_caching"].(bool); ok {
+			promptCachingEnabled = enabled
+		}
+	}
+
+	// Simulate prompt caching (cache 30% of input if enabled)
+	if promptCachingEnabled {
+		cachedInputTokens = inputTokenCount * 30 / 100
+	}
+
+	// Check if thinking mode is enabled
+	var choices []*llms.ContentChoice
+	thinkingConfig := llms.GetThinkingConfig(&opts)
+	if thinkingConfig != nil && thinkingConfig.Mode != llms.ThinkingModeNone && thinkingConfig.Mode != "" {
+		// Calculate thinking tokens based on mode or budget
+		if thinkingConfig.BudgetTokens > 0 {
+			thinkingBudgetAllocated = thinkingConfig.BudgetTokens
+			thinkingBudgetUsed = thinkingConfig.BudgetTokens * 80 / 100 // Use 80% of budget
+			thinkingTokenCount = thinkingBudgetUsed
+		} else {
+			// Calculate based on mode
+			thinkingBudgetAllocated = llms.CalculateThinkingBudget(thinkingConfig.Mode, opts.MaxTokens)
+			thinkingBudgetUsed = thinkingBudgetAllocated * 75 / 100 // Use 75% of calculated budget
+			thinkingTokenCount = thinkingBudgetUsed
+		}
+
+		// Split thinking tokens between input and output
+		thinkingInputTokens = thinkingTokenCount * 20 / 100  // 20% input
+		thinkingOutputTokens = thinkingTokenCount * 80 / 100 // 80% output
+
+		// Simulate some cached thinking tokens if prompt caching is enabled
+		if promptCachingEnabled && thinkingTokenCount > 100 {
+			thinkingCachedTokens = thinkingTokenCount * 15 / 100
+		}
+
+		// Add a mock thinking choice
+		choices = append(choices, &llms.ContentChoice{
+			Content: "",
+			GenerationInfo: map[string]any{
+				"ThinkingContent":           "Let me think step by step about developing a metaprompting system:\n1. Define the core components\n2. Design the prompt structure\n3. Implement feedback loops\n4. Add evaluation metrics",
+				"InputTokens":              inputTokenCount,
+				"OutputTokens":             outputTokenCount + thinkingTokenCount,
+				"TotalTokens":             inputTokenCount + outputTokenCount + thinkingTokenCount,
+				"CachedInputTokens":        cachedInputTokens,
+				"ThinkingTokens":           thinkingTokenCount,
+				"ThinkingInputTokens":      thinkingInputTokens,
+				"ThinkingOutputTokens":     thinkingOutputTokens,
+				"ThinkingCachedTokens":     thinkingCachedTokens,
+				"ThinkingBudgetUsed":       thinkingBudgetUsed,
+				"ThinkingBudgetAllocated":  thinkingBudgetAllocated,
+			},
+		})
+		// Add the main content choice
+		choices = append(choices, &llms.ContentChoice{
+			Content: strings.Join(words, " "),
+			GenerationInfo: map[string]any{
+				"InputTokens":              inputTokenCount,
+				"OutputTokens":             outputTokenCount + thinkingTokenCount,
+				"TotalTokens":             inputTokenCount + outputTokenCount + thinkingTokenCount,
+				"CachedInputTokens":        cachedInputTokens,
+			},
+		})
+	} else {
+		// Normal response without thinking
+		choices = []*llms.ContentChoice{
+			{
+				Content: strings.Join(words, " "),
+				GenerationInfo: map[string]any{
+					"InputTokens":       inputTokenCount,
+					"OutputTokens":      outputTokenCount,
+					"TotalTokens":      inputTokenCount + outputTokenCount,
+					"CachedInputTokens": cachedInputTokens,
+				},
+			},
+		}
+	}
+
+	response := &llms.ContentResponse{
+		Choices: choices,
 	}
 
 	if opts.StreamingFunc != nil {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
-	github.com/tmc/langchaingo v0.1.14-pre.3
+	github.com/tmc/langchaingo v0.1.14-pre.4.0.20250917063452-900c1b9498fa
 	github.com/tmc/spinner v0.1.2
 	go.uber.org/zap v1.27.0
 	golang.org/x/term v0.34.0

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/tmc/langchaingo v0.1.14-pre.3 h1:xuhOrPCX4PxaZP4+tU8+Da1uq5UCUh1QsIppfgofjSE=
-github.com/tmc/langchaingo v0.1.14-pre.3/go.mod h1:xGqIATL4itqqEAVwSF5xVh4ZuIP7gOE0dyoqe3quvzw=
+github.com/tmc/langchaingo v0.1.14-pre.4.0.20250917063452-900c1b9498fa h1:gE0SsItAQ02CG3LT5S/j7+3lK5e6PvpSsidnHPMNUQk=
+github.com/tmc/langchaingo v0.1.14-pre.4.0.20250917063452-900c1b9498fa/go.mod h1:xGqIATL4itqqEAVwSF5xVh4ZuIP7gOE0dyoqe3quvzw=
 github.com/tmc/spinner v0.1.2 h1:ABtcBS5MyBjqALi6worSZknE7RDujJXdo4hqAREY5d0=
 github.com/tmc/spinner v0.1.2/go.mod h1:2BSgX747MqQfTrwzzKJMj4dru08f+Z/1g5m/VbpXoT4=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/history.go
+++ b/history.go
@@ -43,7 +43,7 @@ func (s *CompletionService) loadHistory() error {
 		s.payload.Model = h.Model
 	}
 	s.payload.Messages = h.Messages
-	
+
 	// Load metadata if present
 	if h.Metadata != nil {
 		s.historyMetadata = h.Metadata
@@ -55,12 +55,12 @@ func (s *CompletionService) saveHistory() error {
 	if s.disableHistory {
 		return nil
 	}
-	
+
 	// New history system with file handle
 	if s.historyFile != nil {
 		return s.saveHistoryToFile(s.historyFile)
 	}
-	
+
 	// Legacy history system
 	if s.historyOutFile == "" {
 		home, err := os.UserHomeDir()
@@ -88,31 +88,31 @@ func (s *CompletionService) saveHistoryToFile(f *os.File) error {
 	if s.historyMetadata != nil && s.historyMetadata.Description == "" && len(s.payload.Messages) >= 2 {
 		s.historyMetadata.Description = s.generateDescription()
 	}
-	
+
 	h := history{
 		Metadata: s.historyMetadata,
 		Backend:  s.cfg.Backend,
 		Model:    s.payload.Model,
 		Messages: s.payload.Messages,
 	}
-	
+
 	// Marshal to YAML
 	ybytes, err := yaml.Marshal(h)
 	if err != nil {
 		return fmt.Errorf("failed to marshal history: %w", err)
 	}
-	
+
 	if f != os.Stdout {
 		// Truncate and seek to beginning for updates
 		f.Truncate(0)
 		f.Seek(0, 0)
 	}
-	
+
 	// Write the YAML content
 	if _, err := f.Write(ybytes); err != nil {
 		return fmt.Errorf("failed to write history: %w", err)
 	}
-	
+
 	if f != os.Stdout {
 		return f.Sync()
 	}
@@ -181,7 +181,7 @@ func (s *CompletionService) generateDescription() string {
 	if len(s.payload.Messages) < 2 {
 		return ""
 	}
-	
+
 	// Get first user message
 	var firstUserMsg string
 	for _, msg := range s.payload.Messages {
@@ -197,11 +197,11 @@ func (s *CompletionService) generateDescription() string {
 			}
 		}
 	}
-	
+
 	if firstUserMsg == "" {
 		return ""
 	}
-	
+
 	// Simple keyword extraction (take first 50 chars, clean up)
 	desc := strings.TrimSpace(firstUserMsg)
 	if len(desc) > 50 {
@@ -211,17 +211,17 @@ func (s *CompletionService) generateDescription() string {
 			desc = desc[:idx]
 		}
 	}
-	
+
 	// Remove problematic characters
 	desc = strings.ReplaceAll(desc, "\n", " ")
 	desc = strings.ReplaceAll(desc, "\r", " ")
 	desc = strings.ReplaceAll(desc, "\t", " ")
-	
+
 	// Collapse multiple spaces
 	for strings.Contains(desc, "  ") {
 		desc = strings.ReplaceAll(desc, "  ", " ")
 	}
-	
+
 	return strings.TrimSpace(desc)
 }
 

--- a/history_v2.go
+++ b/history_v2.go
@@ -73,17 +73,17 @@ func (h *historyManager) createNamedLink(sessionPath, name string) error {
 	// Clean the name (remove any path separators, etc)
 	name = strings.ReplaceAll(name, "/", "-")
 	name = strings.ReplaceAll(name, "..", "")
-	
+
 	// Create link with timestamp prefix
 	linkName := fmt.Sprintf("%s-%s.yaml", timestamp, name)
 	linkPath := filepath.Join(namedDir, linkName)
-	
+
 	// Create relative path for symlink
 	relPath := filepath.Join("..", "sessions", base)
-	
+
 	// Remove existing link if it exists
 	os.Remove(linkPath)
-	
+
 	return os.Symlink(relPath, linkPath)
 }
 

--- a/options.go
+++ b/options.go
@@ -29,10 +29,10 @@ type RunOptions struct {
 	DebugMode bool `json:"debugMode,omitempty" yaml:"debugMode,omitempty"`
 
 	// History options
-	HistoryIn           string `json:"historyIn,omitempty" yaml:"historyIn,omitempty"`       // Read history from file (-I)
-	HistoryOut          string `json:"historyOut,omitempty" yaml:"historyOut,omitempty"`     // Write history to file (-O)
-	History             string `json:"history,omitempty" yaml:"history,omitempty"`           // Read+write same file (-H)
-	Continue            bool   `json:"continue,omitempty" yaml:"continue,omitempty"`         // Continue most recent (-C)
+	HistoryIn           string `json:"historyIn,omitempty" yaml:"historyIn,omitempty"`   // Read history from file (-I)
+	HistoryOut          string `json:"historyOut,omitempty" yaml:"historyOut,omitempty"` // Write history to file (-O)
+	History             string `json:"history,omitempty" yaml:"history,omitempty"`       // Read+write same file (-H)
+	Continue            bool   `json:"continue,omitempty" yaml:"continue,omitempty"`     // Continue most recent (-C)
 	ReadlineHistoryFile string `json:"readlineHistoryFile,omitempty" yaml:"readlineHistoryFile,omitempty"`
 	NCompletions        int    `json:"nCompletions,omitempty" yaml:"nCompletions,omitempty"`
 

--- a/payload.go
+++ b/payload.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/anthropic"
 	"github.com/tmc/langchaingo/llms/openai"
 )
 
@@ -18,8 +19,9 @@ var defaultMaxTokens = 2048
 // newCompletionPayload creates a new completion payload.
 func newCompletionPayload(cfg *Config) *ChatCompletionPayload {
 	p := &ChatCompletionPayload{
-		Model:  cfg.Model,
-		Stream: cfg.Stream,
+		Model:         cfg.Model,
+		Stream:        cfg.Stream,
+		PromptCaching: cfg.PromptCaching,
 	}
 	return p
 }
@@ -30,6 +32,9 @@ type ChatCompletionPayload struct {
 	Model    string `json:"model"`
 	Messages []llms.MessageContent
 	Stream   bool `json:"stream,omitempty"`
+
+	// Internal flags for message processing
+	PromptCaching bool `json:"-"`
 }
 
 func (p *ChatCompletionPayload) addMessage(role llms.ChatMessageType, content string) {
@@ -37,7 +42,19 @@ func (p *ChatCompletionPayload) addMessage(role llms.ChatMessageType, content st
 }
 
 func (p *ChatCompletionPayload) addSystemMessage(content string) {
-	p.addMessage(llms.ChatMessageTypeSystem, content)
+	if p.PromptCaching {
+		// When prompt caching is enabled, add cache control to system messages
+		cachedPart := llms.WithCacheControl(
+			llms.TextPart(content),
+			anthropic.EphemeralCache(),
+		)
+		p.Messages = append(p.Messages, llms.MessageContent{
+			Role:  llms.ChatMessageTypeSystem,
+			Parts: []llms.ContentPart{cachedPart},
+		})
+	} else {
+		p.addMessage(llms.ChatMessageTypeSystem, content)
+	}
 }
 
 func (p *ChatCompletionPayload) addUserMessage(content string) {
@@ -93,14 +110,94 @@ func (s *CompletionService) PerformCompletionStreaming(ctx context.Context, payl
 			}
 		}()
 
+		// Determine temperature based on thinking mode
+		temperature := s.cfg.Temperature
+		if (s.cfg.ThinkingBudget > 0 || (s.cfg.ThinkingMode != "" && s.cfg.ThinkingMode != "none")) && s.cfg.Backend == "anthropic" {
+			// Anthropic requires temperature=1 when thinking is enabled
+			temperature = 1.0
+		}
+
+		// Validate max_tokens > budget_tokens constraint for Anthropic
+		maxTokens := s.cfg.MaxTokens
+		if s.cfg.Backend == "anthropic" && (s.cfg.ThinkingBudget > 0 || (s.cfg.ThinkingMode != "" && s.cfg.ThinkingMode != "none")) {
+			// Determine effective thinking budget
+			effectiveBudget := s.cfg.ThinkingBudget
+			if effectiveBudget == 0 && s.cfg.ThinkingMode != "" && s.cfg.ThinkingMode != "none" {
+				// API will use default based on mode, but minimum is 1024
+				effectiveBudget = 1024
+			}
+			// Normalize to API minimum if user set a value below 1024
+			if effectiveBudget > 0 && effectiveBudget < 1024 {
+				effectiveBudget = 1024
+			}
+
+			// Ensure max_tokens > budget_tokens
+			if maxTokens <= effectiveBudget {
+				// Auto-adjust max_tokens to be greater than budget
+				maxTokens = effectiveBudget + 1000
+				// Log the adjustment when it happens
+				fmt.Fprintf(s.Stderr, "Note: Auto-adjusted max_tokens from %d to %d (must be > thinking budget of %d)\n",
+					s.cfg.MaxTokens, maxTokens, effectiveBudget)
+			}
+		}
+
 		callOpts := []llms.CallOption{
-			llms.WithMaxTokens(s.cfg.MaxTokens),
-			llms.WithTemperature(s.cfg.Temperature),
+			llms.WithMaxTokens(maxTokens),
+			llms.WithTemperature(temperature),
 		}
 		if s.useLegacyMaxTokens {
 			callOpts = append(callOpts, openai.WithLegacyMaxTokensField())
 		}
-		callOpts = append(callOpts, llms.WithStreamingFunc(func(ctx context.Context, chunk []byte) error {
+		// Add prompt caching if enabled
+		if s.cfg.PromptCaching {
+			if s.cfg.Backend == "anthropic" {
+				callOpts = append(callOpts, anthropic.WithPromptCaching())
+			} else {
+				callOpts = append(callOpts, llms.WithPromptCaching(true))
+			}
+		}
+		// Add thinking mode or budget if specified (multi-provider support)
+		if s.cfg.ThinkingBudget > 0 {
+			callOpts = append(callOpts, llms.WithThinkingBudget(s.cfg.ThinkingBudget))
+			if s.cfg.ShowReasoning {
+				callOpts = append(callOpts, llms.WithReturnThinking(true))
+			}
+		} else if s.cfg.ThinkingMode != "" && s.cfg.ThinkingMode != "none" {
+			callOpts = append(callOpts, llms.WithThinkingMode(llms.ThinkingMode(s.cfg.ThinkingMode)))
+			if s.cfg.ShowReasoning {
+				callOpts = append(callOpts, llms.WithReturnThinking(true))
+			}
+		}
+		// Add interleaved thinking if enabled (Claude 4+ only)
+		if s.cfg.InterleavedThinking && s.cfg.Backend == "anthropic" {
+			// Use Anthropic-specific option to set the beta header
+			callOpts = append(callOpts, anthropic.WithInterleavedThinking())
+		}
+		// Add streaming reasoning function if we're showing reasoning (multi-provider support)
+	if s.cfg.ShowReasoning && (s.cfg.ThinkingMode != "" && s.cfg.ThinkingMode != "none" || s.cfg.ThinkingBudget > 0) {
+		callOpts = append(callOpts, llms.WithStreamingReasoningFunc(func(ctx context.Context, reasoningChunk, chunk []byte) error {
+			if len(reasoningChunk) > 0 {
+				// Display thinking content as it arrives
+				select {
+				case ch <- string(reasoningChunk):
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			// If there's regular content alongside, stream it too
+			if len(chunk) > 0 {
+				select {
+				case ch <- string(chunk):
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			return nil
+		}))
+	}
+	callOpts = append(callOpts, llms.WithStreamingFunc(func(ctx context.Context, chunk []byte) error {
 			if firstChunk {
 				prefillCleanup()
 				if spinnerStop != nil {
@@ -119,10 +216,63 @@ func (s *CompletionService) PerformCompletionStreaming(ctx context.Context, payl
 			}
 		}))
 
-		_, err := s.model.GenerateContent(genCtx, payload.Messages, callOpts...)
+		resp, err := s.model.GenerateContent(genCtx, payload.Messages, callOpts...)
 
 		if err != nil && !errors.Is(err, context.Canceled) {
 			log.Printf("failed to generate content: %v", err)
+		}
+
+		// Note: With StreamingReasoningFunc support, thinking content now streams
+		// as it arrives (before the main response). The code below handles any
+		// thinking content that wasn't streamed (e.g., from models that don't
+		// support streaming thinking).
+		if resp != nil && len(resp.Choices) > 0 {
+			// Check all choices for thinking content and costs
+			var hasDisplayedCosts bool
+			for _, choice := range resp.Choices {
+				// Display reasoning content if available
+				if choice.ReasoningContent != "" && (s.cfg.ShowReasoning || s.cfg.ShowCosts) {
+					// Check if this is summarized thinking (Claude 4) or full thinking
+					label := "Reasoning"
+					if choice.GenerationInfo != nil {
+						if signature, ok := choice.GenerationInfo["signature"].(string); ok && signature != "" {
+							label = "Reasoning (summarized)"
+						}
+					}
+					select {
+					case ch <- fmt.Sprintf("\n\n--- %s (streaming limitation: shown after response) ---\n%s\n---\n", label, choice.ReasoningContent):
+					case <-ctx.Done():
+					}
+				}
+
+				// Check for thinking content in GenerationInfo (Anthropic style)
+				if s.cfg.ShowReasoning && choice.GenerationInfo != nil {
+					if thinkingContent, ok := choice.GenerationInfo["ThinkingContent"].(string); ok && thinkingContent != "" {
+						label := "Thinking"
+						// Check for signature indicating this is summarized content
+						if signature, ok := choice.GenerationInfo["signature"].(string); ok && signature != "" {
+							label = "Thinking (summarized)"
+						}
+						select {
+						case ch <- fmt.Sprintf("\n\n--- %s (streaming limitation: shown after response) ---\n%s\n---\n", label, thinkingContent):
+						case <-ctx.Done():
+						}
+					}
+					// Handle redacted thinking if present
+					if redactedThinking, ok := choice.GenerationInfo["redacted_thinking"].(string); ok && redactedThinking != "" {
+						select {
+						case ch <- fmt.Sprintf("\n\n--- Thinking (redacted for safety) ---\n%s\n---\n", redactedThinking):
+						case <-ctx.Done():
+						}
+					}
+				}
+
+				// Display costs once (they should be the same across choices)
+				if !hasDisplayedCosts && s.cfg.ShowCosts && choice.GenerationInfo != nil {
+					s.displayCosts(choice.GenerationInfo)
+					hasDisplayedCosts = true
+				}
+			}
 		}
 
 		// Clean up spinner if it's still running
@@ -159,12 +309,58 @@ func (s *CompletionService) PerformCompletion(ctx context.Context, payload *Chat
 		defer stopSpinner()
 	}
 
+	// Determine temperature based on thinking mode
+	temperature := s.cfg.Temperature
+	if (s.cfg.ThinkingBudget > 0 || (s.cfg.ThinkingMode != "" && s.cfg.ThinkingMode != "none")) && s.cfg.Backend == "anthropic" {
+		// Anthropic requires temperature=1 when thinking is enabled
+		temperature = 1.0
+	}
+
+	// Validate max_tokens > budget_tokens constraint for Anthropic
+	maxTokens := s.cfg.MaxTokens
+	if s.cfg.Backend == "anthropic" && (s.cfg.ThinkingBudget > 0 || (s.cfg.ThinkingMode != "" && s.cfg.ThinkingMode != "none")) {
+		// Determine effective thinking budget
+		effectiveBudget := s.cfg.ThinkingBudget
+		if effectiveBudget == 0 && s.cfg.ThinkingMode != "" && s.cfg.ThinkingMode != "none" {
+			// API will use default based on mode, but minimum is 1024
+			effectiveBudget = 1024
+		}
+		// Normalize to API minimum if user set a value below 1024
+		if effectiveBudget > 0 && effectiveBudget < 1024 {
+			effectiveBudget = 1024
+		}
+
+		// Ensure max_tokens > budget_tokens
+		if maxTokens <= effectiveBudget {
+			// Auto-adjust max_tokens to be greater than budget
+			maxTokens = effectiveBudget + 1000
+			// Log the adjustment when it happens
+			fmt.Fprintf(s.Stderr, "Note: Auto-adjusted max_tokens from %d to %d (must be > thinking budget of %d)\n",
+				s.cfg.MaxTokens, maxTokens, effectiveBudget)
+		}
+	}
+
 	callOpts := []llms.CallOption{
-		llms.WithMaxTokens(s.cfg.MaxTokens),
-		llms.WithTemperature(s.cfg.Temperature),
+		llms.WithMaxTokens(maxTokens),
+		llms.WithTemperature(temperature),
 	}
 	if s.useLegacyMaxTokens {
 		callOpts = append(callOpts, openai.WithLegacyMaxTokensField())
+	}
+	// Add prompt caching if enabled
+	if s.cfg.PromptCaching {
+		callOpts = append(callOpts, llms.WithPromptCaching(true))
+	}
+	// Add thinking mode or budget if specified (multi-provider support)
+	if s.cfg.ThinkingBudget > 0 {
+		callOpts = append(callOpts, llms.WithThinkingBudget(s.cfg.ThinkingBudget))
+	} else if s.cfg.ThinkingMode != "" && s.cfg.ThinkingMode != "none" {
+		callOpts = append(callOpts, llms.WithThinkingMode(llms.ThinkingMode(s.cfg.ThinkingMode)))
+	}
+	// Add interleaved thinking if enabled (Claude 4+ only)
+	if s.cfg.InterleavedThinking && s.cfg.Backend == "anthropic" {
+		// Use Anthropic-specific option to set the beta header
+		callOpts = append(callOpts, anthropic.WithInterleavedThinking())
 	}
 	response, err := s.model.GenerateContent(ctx, payload.Messages, callOpts...)
 	if err != nil {
@@ -174,7 +370,54 @@ func (s *CompletionService) PerformCompletion(ctx context.Context, payload *Chat
 		return "", fmt.Errorf("no response from model")
 	}
 
-	content := response.Choices[0].Content
+	// First pass: Display thinking/reasoning before the actual response
+	for _, choice := range response.Choices {
+		// Display reasoning content if available
+		if choice.ReasoningContent != "" && (s.cfg.ShowReasoning || s.cfg.ShowCosts) {
+			// Check if this is summarized thinking (Claude 4) or full thinking
+			label := "Reasoning"
+			if choice.GenerationInfo != nil {
+				if signature, ok := choice.GenerationInfo["signature"].(string); ok && signature != "" {
+					label = "Reasoning (summarized)"
+				}
+			}
+			fmt.Fprintf(s.Stderr, "\n--- %s ---\n%s\n---\n", label, choice.ReasoningContent)
+		}
+
+		// Check for thinking content in GenerationInfo (Anthropic style)
+		if s.cfg.ShowReasoning && choice.GenerationInfo != nil {
+			if thinkingContent, ok := choice.GenerationInfo["ThinkingContent"].(string); ok && thinkingContent != "" {
+				label := "Thinking"
+				// Check for signature indicating this is summarized content
+				if signature, ok := choice.GenerationInfo["signature"].(string); ok && signature != "" {
+					label = "Thinking (summarized)"
+				}
+				fmt.Fprintf(s.Stderr, "\n--- %s ---\n%s\n---\n", label, thinkingContent)
+			}
+			// Handle redacted thinking if present
+			if redactedThinking, ok := choice.GenerationInfo["redacted_thinking"].(string); ok && redactedThinking != "" {
+				fmt.Fprintf(s.Stderr, "\n--- Thinking (redacted for safety) ---\n%s\n---\n", redactedThinking)
+			}
+		}
+	}
+
+	// Second pass: Extract content and display costs
+	var content string
+	var hasDisplayedCosts bool
+
+	for _, choice := range response.Choices {
+		// Collect non-empty content
+		if choice.Content != "" {
+			content = choice.Content
+		}
+
+		// Display costs once
+		if !hasDisplayedCosts && s.cfg.ShowCosts && choice.GenerationInfo != nil {
+			s.displayCosts(choice.GenerationInfo)
+			hasDisplayedCosts = true
+		}
+	}
+
 	if !addedAssistantMessage {
 		payload.addAssistantMessage(content)
 	}
@@ -185,6 +428,99 @@ func (s *CompletionService) PerformCompletion(ctx context.Context, payload *Chat
 // handleAssistantPrefill handles the assistant prefill message.
 // It returns a cleanup function that should be called after the completion is done.
 // The second return value is the location where the spinner could start.
+// displayCosts shows token usage and cost estimates
+func (s *CompletionService) displayCosts(generationInfo map[string]any) {
+	if generationInfo == nil {
+		return
+	}
+
+	// Extract basic token usage
+	var inputTokens, outputTokens, totalTokens int
+	var cachedInputTokens, cachedOutputTokens int
+
+	if v, ok := generationInfo["InputTokens"].(int); ok {
+		inputTokens = v
+	}
+	if v, ok := generationInfo["OutputTokens"].(int); ok {
+		outputTokens = v
+	}
+	if v, ok := generationInfo["TotalTokens"].(int); ok {
+		totalTokens = v
+	} else {
+		// If TotalTokens isn't provided, calculate it
+		totalTokens = inputTokens + outputTokens
+	}
+
+	// Extract cached tokens
+	if v, ok := generationInfo["CachedInputTokens"].(int); ok {
+		cachedInputTokens = v
+	}
+	if v, ok := generationInfo["CachedOutputTokens"].(int); ok {
+		cachedOutputTokens = v
+	}
+
+	// Extract thinking/reasoning tokens if available
+	thinkingUsage := llms.ExtractThinkingTokens(generationInfo)
+
+	// Display token usage
+	fmt.Fprintf(s.Stderr, "\n╭─────────────────────────────────────╮\n")
+	fmt.Fprintf(s.Stderr, "│          TOKEN USAGE REPORT         │\n")
+	fmt.Fprintf(s.Stderr, "├─────────────────────────────────────┤\n")
+
+	// Input tokens
+	fmt.Fprintf(s.Stderr, "│ Input Tokens:        %7d       │\n", inputTokens)
+	if cachedInputTokens > 0 {
+		fmt.Fprintf(s.Stderr, "│   ├─ Cached:        %7d       │\n", cachedInputTokens)
+		fmt.Fprintf(s.Stderr, "│   └─ New:           %7d       │\n", inputTokens-cachedInputTokens)
+	}
+
+	// Output tokens
+	fmt.Fprintf(s.Stderr, "│ Output Tokens:       %7d       │\n", outputTokens)
+	if cachedOutputTokens > 0 {
+		fmt.Fprintf(s.Stderr, "│   └─ Cached:        %7d       │\n", cachedOutputTokens)
+	}
+
+	// Thinking tokens breakdown
+	if thinkingUsage != nil && thinkingUsage.ThinkingTokens > 0 {
+		fmt.Fprintf(s.Stderr, "├─────────────────────────────────────┤\n")
+		fmt.Fprintf(s.Stderr, "│ Thinking/Reasoning:                 │\n")
+		if thinkingUsage.ThinkingInputTokens > 0 || thinkingUsage.ThinkingOutputTokens > 0 {
+			fmt.Fprintf(s.Stderr, "│   ├─ Input:         %7d       │\n", thinkingUsage.ThinkingInputTokens)
+			fmt.Fprintf(s.Stderr, "│   ├─ Output:        %7d       │\n", thinkingUsage.ThinkingOutputTokens)
+			if thinkingUsage.ThinkingCachedTokens > 0 {
+				fmt.Fprintf(s.Stderr, "│   ├─ Cached:        %7d       │\n", thinkingUsage.ThinkingCachedTokens)
+			}
+			fmt.Fprintf(s.Stderr, "│   └─ Total:         %7d       │\n", thinkingUsage.ThinkingTokens)
+		} else {
+			fmt.Fprintf(s.Stderr, "│   Total:             %7d       │\n", thinkingUsage.ThinkingTokens)
+		}
+
+		// Thinking budget if specified
+		if thinkingUsage.ThinkingBudgetAllocated > 0 {
+			percentUsed := float64(thinkingUsage.ThinkingBudgetUsed) / float64(thinkingUsage.ThinkingBudgetAllocated) * 100
+			fmt.Fprintf(s.Stderr, "│   Budget: %d/%d (%.1f%%)    │\n",
+				thinkingUsage.ThinkingBudgetUsed, thinkingUsage.ThinkingBudgetAllocated, percentUsed)
+		}
+	}
+
+	// Total
+	fmt.Fprintf(s.Stderr, "├─────────────────────────────────────┤\n")
+	fmt.Fprintf(s.Stderr, "│ TOTAL:               %7d       │\n", totalTokens)
+
+	// Cache savings summary
+	totalCached := cachedInputTokens + cachedOutputTokens
+	if thinkingUsage != nil {
+		totalCached += thinkingUsage.ThinkingCachedTokens
+	}
+	if totalCached > 0 {
+		cacheSavings := float64(totalCached) / float64(totalTokens) * 100
+		fmt.Fprintf(s.Stderr, "├─────────────────────────────────────┤\n")
+		fmt.Fprintf(s.Stderr, "│ Cache Savings:       %6.1f%%       │\n", cacheSavings)
+	}
+
+	fmt.Fprintf(s.Stderr, "╰─────────────────────────────────────╯\n")
+}
+
 func (s *CompletionService) handleAssistantPrefill(ctx context.Context, payload *ChatCompletionPayload, cfg PerformCompletionConfig) (func(), int) {
 	spinnerPos := 0
 	if s.nextCompletionPrefill == "" {


### PR DESCRIPTION
Add reasoning/thinking support for OpenAI, Anthropic, Google AI, Ollama, and OpenRouter.

- Add thinking modes (low, medium, high, auto) and explicit budget configuration
- Provider-specific validation and auto-adjustment
- Token usage reporting with thinking breakdowns
- Comprehensive test coverage