### PR TITLE
completion: preserve normal output in debug mode

### DIFF
--- a/cmd/cgpt/main_test.go
+++ b/cmd/cgpt/main_test.go
@@ -406,6 +406,9 @@ func TestDuplicateAIRole(t *testing.T) {
 }
 
 func TestMain(t *testing.T) {
+	// Set dummy backend to avoid trying to connect to ollama
+	t.Setenv("CGPT_BACKEND", "dummy")
+	
 	tests := []struct {
 		name    string
 		args    []string

--- a/cmd/cgpt/main_test.go
+++ b/cmd/cgpt/main_test.go
@@ -152,10 +152,10 @@ func Test(t *testing.T) {
 				// Check if ollama is available by attempting to initialize
 				testCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 				defer cancel()
-				
+
 				// Try to run the test with a short timeout
 				runTest(t, testCtx, opts, fs, newTestLogger(t))
-				
+
 				// If context timed out or we got an error, skip the test
 				if testCtx.Err() != nil || strings.Contains(errBuf.String(), "failed to connect") || strings.Contains(errBuf.String(), "connection refused") {
 					t.Skip("Skipping ollama test - ollama not available")
@@ -163,7 +163,7 @@ func Test(t *testing.T) {
 			} else {
 				runTest(t, context.Background(), opts, fs, newTestLogger(t))
 			}
-			
+
 			if *update {
 				updateGoldenFile(t, testInputFile, txtarComment, files, outBuf.Bytes(), errBuf.Bytes(), files["http_payload"])
 				t.SkipNow()
@@ -408,7 +408,7 @@ func TestDuplicateAIRole(t *testing.T) {
 func TestMain(t *testing.T) {
 	// Set dummy backend to avoid trying to connect to ollama
 	t.Setenv("CGPT_BACKEND", "dummy")
-	
+
 	tests := []struct {
 		name    string
 		args    []string

--- a/completion.go
+++ b/completion.go
@@ -33,13 +33,13 @@ type CompletionService struct {
 
 	historyIn           io.Reader
 	historyOutFile      string
-	historyFile         *os.File      // File handle for new history system
+	historyFile         *os.File // File handle for new history system
 	historyManager      *historyManager
 	historyMetadata     *historyMetadata // Metadata for the history file
 	readlineHistoryFile string
 	disableHistory      bool
 	autoNameHistory     bool
-	autoHistory         bool  // Whether this is an auto-generated session
+	autoHistory         bool // Whether this is an auto-generated session
 
 	performCompletionConfig PerformCompletionConfig
 
@@ -92,7 +92,6 @@ func WithUseLegacyMaxTokens(useLegacy bool) CompletionServiceOption {
 		s.useLegacyMaxTokens = useLegacy
 	}
 }
-
 
 // NewCompletionService creates a new CompletionService with the given configuration.
 func NewCompletionService(cfg *Config, model llms.Model, opts ...CompletionServiceOption) (*CompletionService, error) {
@@ -159,10 +158,10 @@ func (s *CompletionService) Run(ctx context.Context, runCfg RunOptions) error {
 		return fmt.Errorf("input handling error: %w", err)
 	}
 	err := s.executeCompletion(ctx, runCfg)
-	
+
 	// Handle post-completion tasks (naming, cleanup)
 	s.finalizeHistory(ctx, runCfg)
-	
+
 	return err
 }
 
@@ -181,7 +180,7 @@ func (s *CompletionService) configure(runCfg RunOptions) error {
 	if err := s.setupHistory(runCfg); err != nil {
 		fmt.Fprintln(s.Stderr, err)
 	}
-	
+
 	if runCfg.Prefill != "" {
 		s.SetNextCompletionPrefill(runCfg.Prefill)
 	}
@@ -258,7 +257,6 @@ func (s *CompletionService) loadedWithHistory() bool {
 	return s.historyIn != nil
 }
 
-
 // setupHistory handles all history flag combinations
 func (s *CompletionService) setupHistory(runCfg RunOptions) error {
 	// Validate flag combinations
@@ -272,24 +270,24 @@ func (s *CompletionService) setupHistory(runCfg RunOptions) error {
 	if runCfg.Continue {
 		flagCount++
 	}
-	
+
 	if flagCount > 1 {
 		return fmt.Errorf("cannot combine -H/--history with -I/-O or -C flags")
 	}
-	
+
 	// Handle each flag type
 	if runCfg.Continue {
 		return s.setupContinue()
 	}
-	
+
 	if runCfg.History != "" {
 		return s.setupHistoryFile(runCfg.History)
 	}
-	
+
 	if runCfg.HistoryIn != "" || runCfg.HistoryOut != "" {
 		return s.setupExplicitHistory(runCfg.HistoryIn, runCfg.HistoryOut)
 	}
-	
+
 	// No history flags = no history
 	s.disableHistory = true
 	return nil
@@ -301,17 +299,17 @@ func (s *CompletionService) setupContinue() error {
 	if err := os.MkdirAll(sessionsDir, 0755); err != nil {
 		return fmt.Errorf("failed to create sessions directory: %w", err)
 	}
-	
+
 	pattern := filepath.Join(sessionsDir, "*.yaml")
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
 		return fmt.Errorf("failed to find sessions: %w", err)
 	}
-	
+
 	if len(matches) == 0 {
 		return fmt.Errorf("no previous sessions found")
 	}
-	
+
 	// Find most recent
 	var latest string
 	var latestTime time.Time
@@ -325,7 +323,7 @@ func (s *CompletionService) setupContinue() error {
 			latestTime = info.ModTime()
 		}
 	}
-	
+
 	return s.setupHistoryFile(latest)
 }
 
@@ -339,15 +337,15 @@ func (s *CompletionService) setupHistoryFile(historySpec string) error {
 		}
 		s.historyOutFile = path
 		s.historyFile = file
-		s.autoHistory = true  // Mark this as an auto-generated session
-		
+		s.autoHistory = true // Mark this as an auto-generated session
+
 		// Initialize metadata for new session
 		s.historyMetadata = &historyMetadata{
 			Created: time.Now().Format(time.RFC3339),
 		}
 		return nil
 	}
-	
+
 	// Explicit file - read from it if exists, write to it
 	if _, err := os.Stat(historySpec); err == nil {
 		// File exists, load it
@@ -357,18 +355,18 @@ func (s *CompletionService) setupHistoryFile(historySpec string) error {
 		}
 		s.historyIn = f
 		defer f.Close()
-		
+
 		if err := s.loadHistory(); err != nil {
 			return fmt.Errorf("failed to load history: %w", err)
 		}
 	}
-	
+
 	// Setup for writing
 	f, err := os.OpenFile(historySpec, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open history file for writing: %w", err)
 	}
-	
+
 	s.historyOutFile = historySpec
 	s.historyFile = f
 	return nil
@@ -384,11 +382,11 @@ func (s *CompletionService) setupExplicitHistory(historyIn, historyOut string) e
 		}
 		s.historyIn = f
 		defer f.Close()
-		
+
 		if err := s.loadHistory(); err != nil {
 			return fmt.Errorf("failed to load history: %w", err)
 		}
-		
+
 		// Track fork if outputting to a different file
 		if historyOut != "" && historyOut != historyIn && historyOut != "-" {
 			if s.historyMetadata == nil {
@@ -401,7 +399,7 @@ func (s *CompletionService) setupExplicitHistory(historyIn, historyOut string) e
 			}
 		}
 	}
-	
+
 	// Setup output if specified
 	if historyOut != "" {
 		if historyOut == "-" {
@@ -419,10 +417,9 @@ func (s *CompletionService) setupExplicitHistory(historyIn, historyOut string) e
 		// If only input specified, disable saving
 		s.disableHistory = true
 	}
-	
+
 	return nil
 }
-
 
 func (s *CompletionService) getLastUserMessage() string {
 	if len(s.payload.Messages) == 0 {
@@ -662,7 +659,7 @@ func (s *CompletionService) finalizeHistory(ctx context.Context, runCfg RunOptio
 	// Close history file if open
 	if s.historyFile != nil && s.historyFile != os.Stdout {
 		s.historyFile.Close()
-		
+
 		// Note: Named session functionality removed for simplicity
 	}
 }

--- a/completion.go
+++ b/completion.go
@@ -437,9 +437,10 @@ func (s *CompletionService) getLastUserMessage() string {
 func (s *CompletionService) runOneShotCompletionStreaming(ctx context.Context, runCfg RunOptions) error {
 	s.logger.Debug("running one-shot completion with streaming")
 
+	// In debug mode, SSEDebugClient adds extra output to stderr but normal processing continues
 	s.payload.Stream = true
 	streamPayloads, err := s.PerformCompletionStreaming(ctx, s.payload, PerformCompletionConfig{
-		ShowSpinner: runCfg.ShowSpinner,
+		ShowSpinner: runCfg.ShowSpinner && !runCfg.DebugMode, // No spinner in debug mode
 		EchoPrefill: runCfg.EchoPrefill,
 	})
 	if err != nil {
@@ -467,9 +468,10 @@ func (s *CompletionService) runOneShotCompletionStreaming(ctx context.Context, r
 func (s *CompletionService) runOneShotCompletion(ctx context.Context, runCfg RunOptions) error {
 	s.logger.Debug("running one-shot completion")
 
+	// In debug mode, SSEDebugClient adds extra output to stderr but normal processing continues
 	s.payload.Stream = false
 	response, err := s.PerformCompletion(ctx, s.payload, PerformCompletionConfig{
-		ShowSpinner: runCfg.ShowSpinner,
+		ShowSpinner: runCfg.ShowSpinner && !runCfg.DebugMode, // No spinner in debug mode
 		EchoPrefill: runCfg.EchoPrefill,
 	})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
-	github.com/tmc/langchaingo v0.1.14-pre.3
+	github.com/tmc/langchaingo v0.1.14-pre.4.0.20250917063452-900c1b9498fa
 	github.com/tmc/spinner v0.1.2
 	go.uber.org/zap v1.27.0
 	golang.org/x/term v0.34.0

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/tmc/langchaingo v0.1.14-pre.3 h1:xuhOrPCX4PxaZP4+tU8+Da1uq5UCUh1QsIppfgofjSE=
-github.com/tmc/langchaingo v0.1.14-pre.3/go.mod h1:xGqIATL4itqqEAVwSF5xVh4ZuIP7gOE0dyoqe3quvzw=
+github.com/tmc/langchaingo v0.1.14-pre.4.0.20250917063452-900c1b9498fa h1:gE0SsItAQ02CG3LT5S/j7+3lK5e6PvpSsidnHPMNUQk=
+github.com/tmc/langchaingo v0.1.14-pre.4.0.20250917063452-900c1b9498fa/go.mod h1:xGqIATL4itqqEAVwSF5xVh4ZuIP7gOE0dyoqe3quvzw=
 github.com/tmc/spinner v0.1.2 h1:ABtcBS5MyBjqALi6worSZknE7RDujJXdo4hqAREY5d0=
 github.com/tmc/spinner v0.1.2/go.mod h1:2BSgX747MqQfTrwzzKJMj4dru08f+Z/1g5m/VbpXoT4=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/history.go
+++ b/history.go
@@ -43,7 +43,7 @@ func (s *CompletionService) loadHistory() error {
 		s.payload.Model = h.Model
 	}
 	s.payload.Messages = h.Messages
-	
+
 	// Load metadata if present
 	if h.Metadata != nil {
 		s.historyMetadata = h.Metadata
@@ -55,12 +55,12 @@ func (s *CompletionService) saveHistory() error {
 	if s.disableHistory {
 		return nil
 	}
-	
+
 	// New history system with file handle
 	if s.historyFile != nil {
 		return s.saveHistoryToFile(s.historyFile)
 	}
-	
+
 	// Legacy history system
 	if s.historyOutFile == "" {
 		home, err := os.UserHomeDir()
@@ -88,31 +88,31 @@ func (s *CompletionService) saveHistoryToFile(f *os.File) error {
 	if s.historyMetadata != nil && s.historyMetadata.Description == "" && len(s.payload.Messages) >= 2 {
 		s.historyMetadata.Description = s.generateDescription()
 	}
-	
+
 	h := history{
 		Metadata: s.historyMetadata,
 		Backend:  s.cfg.Backend,
 		Model:    s.payload.Model,
 		Messages: s.payload.Messages,
 	}
-	
+
 	// Marshal to YAML
 	ybytes, err := yaml.Marshal(h)
 	if err != nil {
 		return fmt.Errorf("failed to marshal history: %w", err)
 	}
-	
+
 	if f != os.Stdout {
 		// Truncate and seek to beginning for updates
 		f.Truncate(0)
 		f.Seek(0, 0)
 	}
-	
+
 	// Write the YAML content
 	if _, err := f.Write(ybytes); err != nil {
 		return fmt.Errorf("failed to write history: %w", err)
 	}
-	
+
 	if f != os.Stdout {
 		return f.Sync()
 	}
@@ -181,7 +181,7 @@ func (s *CompletionService) generateDescription() string {
 	if len(s.payload.Messages) < 2 {
 		return ""
 	}
-	
+
 	// Get first user message
 	var firstUserMsg string
 	for _, msg := range s.payload.Messages {
@@ -197,11 +197,11 @@ func (s *CompletionService) generateDescription() string {
 			}
 		}
 	}
-	
+
 	if firstUserMsg == "" {
 		return ""
 	}
-	
+
 	// Simple keyword extraction (take first 50 chars, clean up)
 	desc := strings.TrimSpace(firstUserMsg)
 	if len(desc) > 50 {
@@ -211,17 +211,17 @@ func (s *CompletionService) generateDescription() string {
 			desc = desc[:idx]
 		}
 	}
-	
+
 	// Remove problematic characters
 	desc = strings.ReplaceAll(desc, "\n", " ")
 	desc = strings.ReplaceAll(desc, "\r", " ")
 	desc = strings.ReplaceAll(desc, "\t", " ")
-	
+
 	// Collapse multiple spaces
 	for strings.Contains(desc, "  ") {
 		desc = strings.ReplaceAll(desc, "  ", " ")
 	}
-	
+
 	return strings.TrimSpace(desc)
 }
 

--- a/history_v2.go
+++ b/history_v2.go
@@ -73,17 +73,17 @@ func (h *historyManager) createNamedLink(sessionPath, name string) error {
 	// Clean the name (remove any path separators, etc)
 	name = strings.ReplaceAll(name, "/", "-")
 	name = strings.ReplaceAll(name, "..", "")
-	
+
 	// Create link with timestamp prefix
 	linkName := fmt.Sprintf("%s-%s.yaml", timestamp, name)
 	linkPath := filepath.Join(namedDir, linkName)
-	
+
 	// Create relative path for symlink
 	relPath := filepath.Join("..", "sessions", base)
-	
+
 	// Remove existing link if it exists
 	os.Remove(linkPath)
-	
+
 	return os.Symlink(relPath, linkPath)
 }
 

--- a/options.go
+++ b/options.go
@@ -29,10 +29,10 @@ type RunOptions struct {
 	DebugMode bool `json:"debugMode,omitempty" yaml:"debugMode,omitempty"`
 
 	// History options
-	HistoryIn           string `json:"historyIn,omitempty" yaml:"historyIn,omitempty"`       // Read history from file (-I)
-	HistoryOut          string `json:"historyOut,omitempty" yaml:"historyOut,omitempty"`     // Write history to file (-O)
-	History             string `json:"history,omitempty" yaml:"history,omitempty"`           // Read+write same file (-H)
-	Continue            bool   `json:"continue,omitempty" yaml:"continue,omitempty"`         // Continue most recent (-C)
+	HistoryIn           string `json:"historyIn,omitempty" yaml:"historyIn,omitempty"`   // Read history from file (-I)
+	HistoryOut          string `json:"historyOut,omitempty" yaml:"historyOut,omitempty"` // Write history to file (-O)
+	History             string `json:"history,omitempty" yaml:"history,omitempty"`       // Read+write same file (-H)
+	Continue            bool   `json:"continue,omitempty" yaml:"continue,omitempty"`     // Continue most recent (-C)
 	ReadlineHistoryFile string `json:"readlineHistoryFile,omitempty" yaml:"readlineHistoryFile,omitempty"`
 	NCompletions        int    `json:"nCompletions,omitempty" yaml:"nCompletions,omitempty"`
 


### PR DESCRIPTION
Simplify debug mode to keep normal parsing and output behavior.

- Debug information (headers, SSE frames) goes to stderr
- Parsed response continues to stdout as usual
- Normal output can be piped/redirected separately from debug info
- No spinner in debug mode